### PR TITLE
Security Fix: Automated Remediation

### DIFF
--- a/tools/provisioning/aws/main.tf
+++ b/tools/provisioning/aws/main.tf
@@ -129,6 +129,10 @@ resource "aws_instance" "tf_test_vm" {
     }
   }
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tags {
     Name      = "${var.name}-${count.index}"
     App       = "${var.app}"


### PR DESCRIPTION

This PR fixes issues found by Terrascan.

### Remediated Findings:
- [MEDIUM] EC2 instances should disable IMDS or require IMDSv2 as this can be related to the weaponization phase of kill chain (tools/provisioning/aws/main.tf:102)
- [MEDIUM] Ensure that your AWS application is not deployed within the default Virtual Private Cloud in order to follow security best practices (tools/provisioning/aws/main.tf:102)


<!-- findings_ids: 687a66aa1fb712124fef0e05,687a66aa1fb712124fef0e04 -->
