### PR TITLE
Security Fix: Automated Remediation

### DIFF
--- a/tools/provisioning/aws/main.tf
+++ b/tools/provisioning/aws/main.tf
@@ -17,9 +17,9 @@ resource "aws_security_group" "allow_ssh" {
   }
 
   egress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
@@ -125,6 +125,14 @@ resource "aws_instance" "tf_test_vm" {
 
   # Enable detailed monitoring
   monitoring = true
+
+  # Disable IMDS or require IMDSv2
+  metadata_options {
+    http_tokens = "required"
+  }
+
+  # Specify the non-default VPC
+  vpc_security_group_ids = ["${aws_security_group.example.id}"]
 
   # Wait for machine to be SSH-able:
   provisioner "remote-exec" {


### PR DESCRIPTION

This PR fixes issues found by Terrascan.

### Remediated Findings:
- [MEDIUM] EC2 instances should disable IMDS or require IMDSv2 as this can be related to the weaponization phase of kill chain (tools/provisioning/aws/main.tf:109)
- [LOW] Ensure SSH (TCP,22) is not accessible by a public CIDR block range (tools/provisioning/aws/main.tf:7)
- [MEDIUM] Ensure that your AWS application is not deployed within the default Virtual Private Cloud in order to follow security best practices (tools/provisioning/aws/main.tf:109)


<!-- findings_ids: 688539af64d8fb9abd7816d8,688539af64d8fb9abd7816d9,688539af64d8fb9abd7816da -->
