### PR TITLE
Security Fix: Automated Remediation

### DIFF
--- a/tools/provisioning/aws/main.tf
+++ b/tools/provisioning/aws/main.tf
@@ -17,9 +17,9 @@ resource "aws_security_group" "allow_ssh" {
   }
 
   egress {
-    from_port   = 22
-    to_port     = 22
-    protocol    = "tcp"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
 
@@ -143,5 +143,9 @@ resource "aws_instance" "tf_test_vm" {
     Name      = "${var.name}-${count.index}"
     App       = "${var.app}"
     CreatedBy = "terraform"
+  }
+
+  metadata_options {
+    http_tokens = "required"
   }
 }


### PR DESCRIPTION

This PR fixes issues found by Terrascan.

### Remediated Findings:
- [MEDIUM] EC2 instances should disable IMDS or require IMDSv2 as this can be related to the weaponization phase of kill chain (tools/provisioning/aws/main.tf:109)
- [LOW] Ensure SSH (TCP,22) is not accessible by a public CIDR block range (tools/provisioning/aws/main.tf:7)


<!-- findings_ids: 6885811b826b71bcad56a741,6885811b826b71bcad56a742 -->
